### PR TITLE
Ignore words occuring in the trend name in sentiment calculations

### DIFF
--- a/spec/twitter/sentiment-bank-spec.js
+++ b/spec/twitter/sentiment-bank-spec.js
@@ -32,4 +32,13 @@ describe('SentimentBank', () => {
 
     expect(sentimentBank.getSentiment()).toEqual(averageSen)
   })
+
+  it('Ignores all words occuring in the trend name', () => {
+    let trendName = 'Bad Horrible trend name with negative sentiment'
+    let sentimentBank = new SentimentBank(trendName)
+
+    sentimentBank.addText('Bad Horrible Negative')
+
+    expect(sentimentBank.getSentiment()).toEqual(0)
+  })
 })

--- a/src/twitter/sentiment-bank.js
+++ b/src/twitter/sentiment-bank.js
@@ -2,12 +2,18 @@
 const sentiment = require('sentiment')
 
 /**
- * Construct a new SentimentBank object.
+ * Construct a new SentmentBank object. A SentimentBank is used to keep track
+ * of sentiment for incoming text on a particular topic.
  *
  */
-function SentimentBank () {
+function SentimentBank (trendName = '') {
   let analyzed = 0
   let totalSentiment = 0
+
+  // Ignore words occuring in the trend name in sentiment calculations
+  let ignoreQuery = {}
+  trendName.split(' ').map(word => { return word.replace(/[^a-zA-Z]/g, '').toLowerCase() })
+  .forEach(word => { ignoreQuery[word] = 0 })
 
   /**
    * Add a tweet to the tweet sentiment analysis.
@@ -15,7 +21,7 @@ function SentimentBank () {
    * @param {String} tweetText Text to analyzed and add to average
    */
   this.addText = function (tweet) {
-    totalSentiment += sentiment(tweet).score
+    totalSentiment += sentiment(tweet, ignoreQuery).score
     analyzed++
   }
 

--- a/src/twitter/tweet-stream.js
+++ b/src/twitter/tweet-stream.js
@@ -46,7 +46,7 @@ function TweetStream () {
     trendData = {}
     trends.forEach(trend => {
       trendData[trend] = {
-        sentimentBank: new SentimentBank(),
+        sentimentBank: new SentimentBank(trend),
         keywordBank: new KeywordBank(),
         tweets_analyzed: 0
       }


### PR DESCRIPTION
A trend name may have words in it that are negative, however the
sentiment of the trend is positive, throwing off the sentiment
analysis. This commit makes the SentimentBank ignore all words
occuring in the trend name when calculating sentiments.